### PR TITLE
Feature/no-upload-flag

### DIFF
--- a/build_and_analyze.py
+++ b/build_and_analyze.py
@@ -43,7 +43,7 @@ if ('-misra' in sys.argv):
     sys.argv.remove('-misra')
 
 uploadFlag = '-remote-archive \"/saas/*\"'
-if ('-noupload' in sys.argv)
+if ('-noupload' in sys.argv):
     uploadFlag = ''
     sys.argv.remove('-noupload')
 

--- a/build_and_analyze.py
+++ b/build_and_analyze.py
@@ -127,11 +127,25 @@ if os.getenv('IS_PR') == 'pull_request' or os.getenv('IS_PR') == 'merge_request_
 namestr = datetime.now().strftime("%m/%d/%Y-%H:%M:%S")
 
 #Perform the actual build
-command = [os.getenv('CSONAR_CSHOME') + "/codesonar/bin/codesonar", 
+if (uploadFlag == ""):
+    command = [os.getenv('CSONAR_CSHOME') + "/codesonar/bin/codesonar", 
                       "build",
                       "-clean",
                       os.getenv("PROJECT_NAME"),
-                        uploadFlag,
+                        "-foreground",
+                        "-auth", "password", 
+                        "-hubuser", os.getenv('CSONAR_HUB_USER'),
+                        "-hubpwfile", CSONAR_HUB_PW_FILE,
+                        "-project", os.getenv("ROOT_TREE") + "/" + os.getenv("BRANCH_NAME"),
+                        "-name", namestr,
+                        "-conf-file", conf_file,
+                        os.getenv("CSONAR_HUB_URL")] + build_command
+else:
+       command = [os.getenv('CSONAR_CSHOME') + "/codesonar/bin/codesonar", 
+                      "build",
+                      "-clean",
+                      os.getenv("PROJECT_NAME"),
+                        "-remote-archive",  "\"/saas/*\"",
                         "-foreground",
                         "-auth", "password", 
                         "-hubuser", os.getenv('CSONAR_HUB_USER'),

--- a/build_and_analyze.py
+++ b/build_and_analyze.py
@@ -42,6 +42,11 @@ if ('-misra' in sys.argv):
     MISRA=True
     sys.argv.remove('-misra')
 
+uploadFlag = '-remote-archive \"/saas/*\"'
+if ('-noupload' in sys.argv)
+    uploadFlag = ''
+    sys.argv.remove('-noupload')
+
 conf_file = sys.argv[1]
 build_command=[]
 build_command = sys.argv[2:]
@@ -126,7 +131,7 @@ command = [os.getenv('CSONAR_CSHOME') + "/codesonar/bin/codesonar",
                       "build",
                       "-clean",
                       os.getenv("PROJECT_NAME"),
-                      "-remote-archive", "/saas/*",
+                        uploadFlag,
                         "-foreground",
                         "-auth", "password", 
                         "-hubuser", os.getenv('CSONAR_HUB_USER'),
@@ -187,7 +192,7 @@ else:
     targetStr=os.getenv('TARGET')
 
 commandstr = os.getenv('CSONAR_CSHOME') + "/codesonar/bin/codesonar analyze " + \
-     os.getenv("PROJECT_NAME") + " -remote-archive \"/saas/*\" -foreground " +  \
+     os.getenv("PROJECT_NAME") + uploadFlag + " -foreground " +  \
             " -auth password" + \
             " -hubuser " + os.getenv('CSONAR_HUB_USER') + " -hubpwfile " + CSONAR_HUB_PW_FILE + \
             " -project " + os.getenv("ROOT_TREE") + "/" + os.getenv("BRANCH_NAME") + \


### PR DESCRIPTION
You can now add '-noupload' to the command line, which skips the upload step, speeding up things a bit for the new languages as there is little use for the program model in the first place.